### PR TITLE
Gravel dev

### DIFF
--- a/src/main/java/com/jagrosh/vortex/Vortex.java
+++ b/src/main/java/com/jagrosh/vortex/Vortex.java
@@ -123,6 +123,8 @@ public class Vortex
                             new VoicemoveCmd(this),
                             new VoicekickCmd(this),
                             new MuteCmd(this),
+                            new GravelCmd(this),
+                            new UngravelCmd(this),
                             new UnmuteCmd(this),
                             new RaidCmd(this),
                             new StrikeCmd(this),

--- a/src/main/java/com/jagrosh/vortex/automod/AutoMod.java
+++ b/src/main/java/com/jagrosh/vortex/automod/AutoMod.java
@@ -63,8 +63,9 @@ public class AutoMod
     
     private static final String CONDENSER = "(.+?)\\s*(\\1\\s*)+";
     private static final Logger LOG = LoggerFactory.getLogger("AutoMod");
-    public  static final String RESTORE_MUTE_ROLE_AUDIT = "Restoring Muted Role";
-    
+    public  static final String RESTORE_MUTE_ROLE_AUDIT =   "Restoring Muted Role";
+    public  static final String RESTORE_GRAVEL_ROLE_AUDIT = "Restoring Gravel Role";
+
     private final Vortex vortex;
     
     private String[] refLinkList;
@@ -192,6 +193,15 @@ public class AutoMod
                     event.getGuild().getController()
                             .addSingleRoleToMember(event.getMember(), vortex.getDatabase().settings.getSettings(event.getGuild()).getMutedRole(event.getGuild()))
                             .reason(RESTORE_MUTE_ROLE_AUDIT).queue();
+                } catch(Exception ignore){}
+            }
+            if(vortex.getDatabase().gravels.isGraveled(event.getMember()))
+            {
+                try
+                {
+                    event.getGuild().getController()
+                            .addSingleRoleToMember(event.getMember(), vortex.getDatabase().settings.getSettings(event.getGuild()).getGravelRole(event.getGuild()))
+                            .reason(RESTORE_GRAVEL_ROLE_AUDIT).queue();
                 } catch(Exception ignore){}
             }
             dehoist(event.getMember());

--- a/src/main/java/com/jagrosh/vortex/commands/moderation/GravelCmd.java
+++ b/src/main/java/com/jagrosh/vortex/commands/moderation/GravelCmd.java
@@ -1,0 +1,117 @@
+package com.jagrosh.vortex.commands.moderation;
+
+import java.util.List;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.vortex.Vortex;
+import com.jagrosh.vortex.commands.ModCommand;
+import net.dv8tion.jda.core.Permission;
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.Role;
+import com.jagrosh.vortex.utils.ArgsUtil;
+import com.jagrosh.vortex.utils.FormatUtil;
+import com.jagrosh.vortex.utils.LogUtil;
+import java.util.LinkedList;
+
+
+public class GravelCmd extends ModCommand
+{
+    public GravelCmd(Vortex vortex)
+    {
+        super(vortex, Permission.MANAGE_ROLES);
+        this.name = "gravel";
+        this.arguments = "<@users> [reason]";
+        this.help = "gravels users";
+        this.botPermissions = new Permission[]{Permission.MANAGE_ROLES};
+        this.guildOnly = true;
+    }
+
+    @Override
+    protected void execute(CommandEvent event)
+    {
+        Role gravelRole = vortex.getDatabase().settings.getSettings(event.getGuild()).getGravelRole(event.getGuild());
+        if(gravelRole == null)
+        {
+            event.replyError("No Gravel role exists!");
+            return;
+        }
+        if(!event.getMember().canInteract(gravelRole))
+        {
+            event.replyError("You do not have permission to gravel people!");
+            return;
+        }
+        if(!event.getSelfMember().canInteract(gravelRole))
+        {
+            event.reply(event.getClient().getError()+" I do not have permissions to assign the '"+gravelRole.getName()+"' role!");
+            return;
+        }
+
+        ArgsUtil.ResolvedArgs args = ArgsUtil.resolve(event.getArgs(), false, event.getGuild());
+        if(args.isEmpty())
+        {
+            event.replyError("Please include at least one user to gravel (@mention or ID)!");
+            return;
+        }
+
+        String reason = LogUtil.auditReasonFormat(event.getMember(), args.reason);
+        Role modrole = vortex.getDatabase().settings.getSettings(event.getGuild()).getModeratorRole(event.getGuild());
+        StringBuilder builder = new StringBuilder();
+        List<Member> toGravel = new LinkedList<>();
+
+        args.members.forEach(m ->
+        {
+            if(!event.getMember().canInteract(m))
+                builder.append("\n").append(event.getClient().getError()).append(" You do not have permission to gravel ").append(FormatUtil.formatUser(m.getUser()));
+            else if(!event.getSelfMember().canInteract(m))
+                builder.append("\n").append(event.getClient().getError()).append(" I am unable to gravel ").append(FormatUtil.formatUser(m.getUser()));
+            else if(m.getRoles().contains(gravelRole))
+                builder.append("\n").append(event.getClient().getError()).append(" ").append(FormatUtil.formatUser(m.getUser())).append(" is already graveled!");
+            else if(modrole!=null && m.getRoles().contains(modrole))
+                builder.append("\n").append(event.getClient().getError()).append(" I won't gravel ").append(FormatUtil.formatUser(m.getUser())).append(" because they have the Moderator Role");
+            else
+                toGravel.add(m);
+        });
+
+        args.unresolved.forEach(un -> builder.append("\n").append(event.getClient().getWarning()).append(" Could not resolve `").append(un).append("` to a member"));
+
+        args.users.forEach(u -> builder.append("\n").append(event.getClient().getWarning()).append(" The user ").append(u.getAsMention()).append(" is not in this server."));
+
+        args.ids.forEach(id -> builder.append("\n").append(event.getClient().getWarning()).append(" The user <@").append(id).append("> is not in this server."));
+
+        if(toGravel.isEmpty())
+        {
+            event.reply(builder.toString());
+            return;
+        }
+
+        if(toGravel.size() > 5)
+            event.reactSuccess();
+
+        for(int i=0; i<toGravel.size(); i++)
+        {
+            Member m = toGravel.get(i);
+            boolean last = i+1 == toGravel.size();
+            event.getGuild().getController().addSingleRoleToMember(m, gravelRole).reason(reason).queue(success ->
+            {
+                vortex.getDatabase().gravels.gravel(event.getGuild(), m.getUser().getIdLong());
+                String user = FormatUtil.formatUser(m.getUser());
+                String[] messages = {
+                        " "+user+" was banished to the gravel pit",
+                        " "+user+" was graveled",
+                        " "+user+" was sent to find flint",
+                        " Added gravel to " + user,
+                        " "+user+" fell in a pit of gravel",
+                        " Successfully poured some gravel on "+user
+                };
+
+                builder.append("\n").append(event.getClient().getSuccess()).append(messages[(int) (Math.random()*messages.length+0.5)]);
+                if(last)
+                    event.reply(builder.toString());
+            }, failure ->
+            {
+                builder.append("\n").append(event.getClient().getError()).append(" Failed to gravel ").append(m.getUser().getAsMention());
+                if(last)
+                    event.reply(builder.toString());
+            });
+        }
+    }
+}

--- a/src/main/java/com/jagrosh/vortex/commands/moderation/UngravelCmd.java
+++ b/src/main/java/com/jagrosh/vortex/commands/moderation/UngravelCmd.java
@@ -1,0 +1,109 @@
+package com.jagrosh.vortex.commands.moderation;
+
+import java.util.List;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.vortex.Vortex;
+import com.jagrosh.vortex.commands.ModCommand;
+import net.dv8tion.jda.core.Permission;
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.Role;
+import com.jagrosh.vortex.utils.ArgsUtil;
+import com.jagrosh.vortex.utils.FormatUtil;
+import com.jagrosh.vortex.utils.LogUtil;
+import java.util.LinkedList;
+
+
+public class UngravelCmd extends ModCommand
+{
+    public UngravelCmd(Vortex vortex)
+    {
+        super(vortex, Permission.MANAGE_ROLES);
+        this.name = "ungravel";
+        this.arguments = "<@users> [reason]";
+        this.help = "ungravels users";
+        this.botPermissions = new Permission[]{Permission.MANAGE_ROLES};
+        this.guildOnly = true;
+    }
+
+    @Override
+    protected void execute(CommandEvent event)
+    {
+        Role gravelRole = vortex.getDatabase().settings.getSettings(event.getGuild()).getGravelRole(event.getGuild());
+        if(gravelRole == null)
+        {
+            event.replyError("No Gravel role exists!");
+            return;
+        }
+        if(!event.getMember().canInteract(gravelRole))
+        {
+            event.replyError("You do not have permission to ungravel people!");
+            return;
+        }
+        if(!event.getSelfMember().canInteract(gravelRole))
+        {
+            event.reply(event.getClient().getError()+" I do not have permissions to unassign the '"+gravelRole.getName()+"' role!");
+            return;
+        }
+
+        ArgsUtil.ResolvedArgs args = ArgsUtil.resolve(event.getArgs(), false, event.getGuild());
+        if(args.isEmpty())
+        {
+            event.replyError("Please include at least one user to ungravel (@mention or ID)!");
+            return;
+        }
+
+        String reason = LogUtil.auditReasonFormat(event.getMember(), args.reason);
+        Role modrole = vortex.getDatabase().settings.getSettings(event.getGuild()).getModeratorRole(event.getGuild());
+        StringBuilder builder = new StringBuilder();
+        List<Member> toGravel = new LinkedList<>();
+
+        args.members.forEach(m ->
+        {
+            if(!event.getMember().canInteract(m))
+                builder.append("\n").append(event.getClient().getError()).append(" You do not have permission to ungravel ").append(FormatUtil.formatUser(m.getUser()));
+            else if(!event.getSelfMember().canInteract(m))
+                builder.append("\n").append(event.getClient().getError()).append(" I am unable to ungravel ").append(FormatUtil.formatUser(m.getUser()));
+            else if(!m.getRoles().contains(gravelRole))
+                builder.append("\n").append(event.getClient().getError()).append(" ").append(FormatUtil.formatUser(m.getUser())).append(" isn't graveled");
+            else if(modrole!=null && m.getRoles().contains(modrole))
+                builder.append("\n").append(event.getClient().getError()).append(" I won't ungravel ").append(FormatUtil.formatUser(m.getUser())).append(" because they have the Moderator Role");
+            else
+                toGravel.add(m);
+        });
+
+        args.unresolved.forEach(un -> builder.append("\n").append(event.getClient().getWarning()).append(" Could not resolve `").append(un).append("` to a member"));
+
+        args.users.forEach(u -> builder.append("\n").append(event.getClient().getWarning()).append(" The user ").append(u.getAsMention()).append(" is not in this server."));
+
+        args.ids.forEach(id -> builder.append("\n").append(event.getClient().getWarning()).append(" The user <@").append(id).append("> is not in this server."));
+
+        if(toGravel.isEmpty())
+        {
+            event.reply(builder.toString());
+            return;
+        }
+
+        if(toGravel.size() > 5)
+            event.reactSuccess();
+
+        for(int i=0; i<toGravel.size(); i++)
+        {
+            Member m = toGravel.get(i);
+            boolean last = i+1 == toGravel.size();
+            event.getGuild().getController().removeSingleRoleFromMember(m, gravelRole).reason(reason).queue(success ->
+            {
+                vortex.getDatabase().gravels.ungravel(event.getGuild(), m.getUser().getIdLong());
+                String user = FormatUtil.formatUser(m.getUser());
+
+                builder.append("\n").append(event.getClient().getSuccess()).append(" "+user+" was ungraveled");
+                if(last)
+                    event.reply(builder.toString());
+            }, failure ->
+            {
+                builder.append("\n").append(event.getClient().getError()).append(" Failed to gravel ").append(m.getUser().getAsMention());
+                if(last)
+                    event.reply(builder.toString());
+            });
+        }
+    }
+}

--- a/src/main/java/com/jagrosh/vortex/database/Database.java
+++ b/src/main/java/com/jagrosh/vortex/database/Database.java
@@ -31,6 +31,7 @@ public class Database extends DatabaseConnector
     public final StrikeManager strikes; // strike counts for members
     public final PunishmentManager actions; // strike punishment settings
     public final TempMuteManager tempmutes;
+    public final GravelManager gravels;
     public final TempBanManager tempbans;
     public final PremiumManager premium;
     public final InviteWhitelistManager inviteWhitelist;
@@ -47,6 +48,7 @@ public class Database extends DatabaseConnector
         strikes = new StrikeManager(this);
         actions = new PunishmentManager(this);
         tempmutes = new TempMuteManager(this);
+        gravels = new GravelManager(this);
         tempbans = new TempBanManager(this);
         premium = new PremiumManager(this);
         inviteWhitelist = new InviteWhitelistManager(this);

--- a/src/main/java/com/jagrosh/vortex/database/managers/GravelManager.java
+++ b/src/main/java/com/jagrosh/vortex/database/managers/GravelManager.java
@@ -1,0 +1,66 @@
+package com.jagrosh.vortex.database.managers;
+
+import com.jagrosh.easysql.DataManager;
+import com.jagrosh.easysql.DatabaseConnector;
+import com.jagrosh.easysql.SQLColumn;
+import com.jagrosh.easysql.columns.InstantColumn;
+import com.jagrosh.easysql.columns.LongColumn;
+
+import java.sql.ResultSet;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.Permission;
+import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.Role;
+
+public class GravelManager extends DataManager
+{
+    public static final SQLColumn<Long> GUILD_ID = new LongColumn("GUILD_ID", false, 0);
+    public static final SQLColumn<Long> USER_ID = new LongColumn("USER_ID", false, 0);
+
+    public GravelManager(DatabaseConnector connector)
+    {
+        super(connector, "GRAVELS");
+    }
+
+    @Override
+    protected String primaryKey()
+    {
+        return GUILD_ID+", "+USER_ID;
+    }
+
+    public boolean isGraveled(Member member)
+    {
+        return read(selectAll(GUILD_ID.is(member.getGuild().getId())+" AND "+USER_ID.is(member.getUser().getId())),
+                ResultSet::next);
+    }
+
+    public void gravel(Guild guild, long userId)
+    {
+        readWrite(selectAll(GUILD_ID.is(guild.getId())+" AND "+USER_ID.is(userId)), rs ->
+        {
+            if(rs.next())
+            {
+                rs.updateRow();
+            }
+            else
+            {
+                rs.moveToInsertRow();
+                GUILD_ID.updateValue(rs, guild.getIdLong());
+                USER_ID.updateValue(rs, userId);
+                rs.insertRow();
+            }
+        });
+    }
+
+    public void ungravel(Guild guild, long userId)
+    {
+        readWrite(selectAll(GUILD_ID.is(guild.getId())+" AND "+USER_ID.is(userId)), rs ->
+        {
+            if(rs.next())
+                rs.deleteRow();
+        });
+    }
+}

--- a/src/main/java/com/jagrosh/vortex/database/managers/GuildSettingsDataManager.java
+++ b/src/main/java/com/jagrosh/vortex/database/managers/GuildSettingsDataManager.java
@@ -93,9 +93,11 @@ public class GuildSettingsDataManager extends DataManager implements GuildSettin
         TextChannel avylog = settings.getAvatarLogChannel(guild);
         Role modrole = settings.getModeratorRole(guild);
         Role muterole = settings.getMutedRole(guild);
+        Role gravelrole = settings.getGravelRole(guild);
         return new Field(SETTINGS_TITLE, "Prefix: `"+(settings.prefix==null ? Constants.PREFIX : settings.prefix)+"`"
                 + "\nMod Role: "+(modrole==null ? "None" : modrole.getAsMention())
                 + "\nMuted Role: "+(muterole==null ? "None" : muterole.getAsMention())
+                + "\nGravel Role: "+(gravelrole==null ? "None" : gravelrole.getAsMention())
                 + "\nMod Log: "+(modlog==null ? "None" : modlog.getAsMention())
                 + "\nMessage Log: "+(messagelog==null ? "None" : messagelog.getAsMention())
                 + "\nVoice Log: "+(voicelog==null ? "None" : voicelog.getAsMention())
@@ -335,7 +337,7 @@ public class GuildSettingsDataManager extends DataManager implements GuildSettin
     
     public class GuildSettings implements GuildSettingsProvider
     {
-        private final long modRole, muteRole, modlog, serverlog, messagelog, voicelog, avatarlog;
+        private final long modRole, muteRole, gravelRole, modlog, serverlog, messagelog, voicelog, avatarlog;
         private final String prefix;
         private final ZoneId timezone;
         private final int raidMode;
@@ -345,6 +347,7 @@ public class GuildSettingsDataManager extends DataManager implements GuildSettin
             this.modRole = 0;
             this.modlog = 0;
             this.muteRole = 0;
+            this.gravelRole = 0;
             this.serverlog = 0;
             this.messagelog = 0;
             this.voicelog = 0;
@@ -358,6 +361,7 @@ public class GuildSettingsDataManager extends DataManager implements GuildSettin
         {
             this.modRole = MOD_ROLE_ID.getValue(rs);
             this.muteRole = 0;
+            this.gravelRole = 0;
             this.modlog = MODLOG_ID.getValue(rs);
             this.serverlog = SERVERLOG_ID.getValue(rs);
             this.messagelog = MESSAGELOG_ID.getValue(rs);
@@ -391,6 +395,14 @@ public class GuildSettingsDataManager extends DataManager implements GuildSettin
             if(rid!=null)
                 return rid;
             return guild.getRoles().stream().filter(r -> r.getName().equalsIgnoreCase("Muted")).findFirst().orElse(null);
+        }
+
+        public Role getGravelRole(Guild guild)
+        {
+            Role rid = guild.getRoleById(gravelRole);
+            if(rid!=null)
+                return rid;
+            return guild.getRoles().stream().filter(r -> r.getName().equalsIgnoreCase("Gravel")).findFirst().orElse(null);
         }
         
         public TextChannel getModLogChannel(Guild guild)

--- a/src/main/java/com/jagrosh/vortex/logging/ModLogger.java
+++ b/src/main/java/com/jagrosh/vortex/logging/ModLogger.java
@@ -265,8 +265,8 @@ public class ModLogger
                 if(act!=null)
                 {
                     User mod = ale.getUser();
-                    if(ale.getJDA().getSelfUser().equals(mod) && act==Action.MUTE && AutoMod.RESTORE_MUTE_ROLE_AUDIT.equals(ale.getReason()))
-                        continue; // restoring muted role shouldn't trigger a log entry
+                    if(ale.getJDA().getSelfUser().equals(mod) && act==Action.MUTE && (AutoMod.RESTORE_MUTE_ROLE_AUDIT.equals(ale.getReason()) || AutoMod.RESTORE_GRAVEL_ROLE_AUDIT.equals(ale.getReason())))
+                        continue; // restoring muted or gravel role (aka role persist) shouldn't trigger a log entry
                     String reason = ale.getReason()==null ? "" : ale.getReason();
                     int minutes = 0;
                     User target = vortex.getShardManager().getUserById(ale.getTargetIdLong());


### PR DESCRIPTION
Add gravel and ungravel commands, as well as a role persist so offenders cannot leave the server to be ungraveled.

For anyone not developing this project, a gravel is like a mute, but the offenders cannot see any channels besides a special channel called gravel-pit where they will be allowed to talk with moderators and other offenders. That is what it is intended to be used for, but its really just an assignable role.